### PR TITLE
Documentation!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Forward simulation with tree sequence recording in rust
+
+This package is currently "experimental"!
+
+`forrustts` (pronounced "forests") is a port of many ideas from the [fwdpp](https://github.com/molpopgen/fwdpp) library from C++ to rust.
+
+It is licensed under the GNU General Public License, version 3 or later ("GPL3+").
+
+## Getting started
+
+[Install rust](https://www.rust-lang.org/learn/get-started)
+
+Then:
+
+```
+cargo build
+cargo test
+```
+
+Example programs are in the subdirectory `forrustts_examples`:
+
+```
+cd forrustts_examples
+cargo build --release
+```
+
+The binaries will then be found in `target/release/`.
+
+These programs use [clap](https://crates.io/crates/clap) for command-line options.
+Pass ``--help`` to any of them for usage information.
+
+## Development information
+
+## CI
+
+CI testing is done using GitHub actions for both `Linux` and `macOS`.
+These actions include using [clippy](https://crates.io/crates/clippy/0.0.211), which is a very strict code linter.
+The actions also check code format using [rustfmt](https://crates.io/crates/rustfmt-nightly).
+
+### Code coverage
+
+Use [tarpaulin](https://docs.rs/crate/cargo-tarpaulin/0.3.12).
+The documentation for that crate is excellent.
+The short version is:
+
+```
+cargo tarpaulin -o html
+```
+
+This command will run the tests and generate a nice `html` report.
+
+

--- a/forrustts_examples/neutral_wf.rs
+++ b/forrustts_examples/neutral_wf.rs
@@ -11,10 +11,10 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("generations")
-                .short("g")
-                .long("generations")
-                .help("number of generations to simulate")
+            Arg::with_name("nsteps")
+                .short("n")
+                .long("nsteps")
+                .help("number of birth steps to simulate")
                 .takes_value(true),
         )
         .arg(
@@ -63,7 +63,7 @@ fn main() {
     // TODO: default params
 
     let popsize = value_t_or_exit!(matches.value_of("popsize"), u32);
-    let g = value_t_or_exit!(matches.value_of("generations"), i64);
+    let g = value_t_or_exit!(matches.value_of("nsteps"), i64);
     let rho = value_t_or_exit!(matches.value_of("rho"), f64);
     let simplify_input = value_t!(matches.value_of("simplification_interval"), i64).unwrap_or(-1);
     let psurvival = value_t!(matches.value_of("psurvival"), f64).unwrap_or(0.0);
@@ -83,7 +83,7 @@ fn main() {
     let flags = if matches.is_present("buffer_edges") {
         SimulationFlags::BUFFER_EDGES
     } else {
-        SimulationFlags::empty()
+        SimulationFlags::USE_STATE
     };
 
     let (mut tables, is_sample) = neutral_wf(
@@ -93,7 +93,7 @@ fn main() {
             littler: r,
             psurvival,
         },
-        SimulationParameters {
+        SimulationParams {
             simplification_interval: simplify,
             seed,
             nsteps: g,

--- a/src/edge_buffer.rs
+++ b/src/edge_buffer.rs
@@ -1,4 +1,13 @@
 use crate::nested_forward_list::NestedForwardList;
 use crate::segment::Segment;
 
+/// Data type used for edge buffering.
+/// Simplification of simulated data happens
+/// via [``crate::simplify_from_edge_buffer()``].
+///
+/// # Example
+///
+/// For a full example of use in simulation,
+/// see the source code for
+/// [``crate::wright_fisher::neutral_wf()``].
 pub type EdgeBuffer = NestedForwardList<Segment>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,31 @@
+///! Error handling
 use crate::nested_forward_list::NestedForwardListError;
 use thiserror::Error;
 
+/// Primary error type.
+///
+/// Some members of this enum implement ``From``
+/// in order to redirect other error types.
 #[derive(Error, Debug)]
 pub enum ForrusttsError {
+    /// An error that occurs during simplification.
     #[error("{value:?}")]
-    SimplificationError { value: String },
+    SimplificationError {
+        /// The error message
+        value: String,
+    },
+
+    /// A redirection of a [``crate::nested_forward_list::NestedForwardListError``].
     #[error("{value:?}")]
     ListError {
+        /// The redirected error
         #[from]
         value: NestedForwardListError,
     },
+    /// A redirection of a [``crate::TablesError``]
     #[error("{value:?}")]
     TablesError {
+        /// The redirected error
         #[from]
         value: crate::TablesError,
     },
@@ -26,7 +40,7 @@ mod test {
         if f {
             Ok(())
         } else {
-            Err(NestedForwardListError::InvalidKey)
+            Err(NestedForwardListError::InvalidIndex)
         }
     }
 
@@ -34,11 +48,8 @@ mod test {
         match return_nested_forward_list_error(false) {
             Ok(_) => Ok(()),
             Err(e) => match e {
-                NestedForwardListError::InvalidKey => Err(ForrusttsError::ListError { value: e }),
+                NestedForwardListError::InvalidIndex => Err(ForrusttsError::ListError { value: e }),
                 NestedForwardListError::NullTail => Err(ForrusttsError::ListError { value: e }),
-                NestedForwardListError::KeyOutOfRange => {
-                    Err(ForrusttsError::ListError { value: e })
-                }
                 #[allow(unreachable_patterns)]
                 _ => panic!(),
             },
@@ -51,11 +62,10 @@ mod test {
             Ok(_) => panic!(),
             Err(e) => match e {
                 ForrusttsError::ListError { value } => match value {
-                    NestedForwardListError::InvalidKey => {
-                        assert_eq!(value.to_string(), "Invalid key")
+                    NestedForwardListError::InvalidIndex => {
+                        assert_eq!(value.to_string(), "Invalid index")
                     }
                     NestedForwardListError::NullTail => panic!(),
-                    NestedForwardListError::KeyOutOfRange => panic!(),
                 },
                 #[allow(unreachable_patterns)]
                 _ => panic!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,43 @@
+//! Rust library for forward time population
+//! genetic simulation with tree sequence recording.
+//!
+//! # Overview
+//!
+//! This package is a port of many ideas from
+//! [fwdpp](https://github.com/molpopgen/fwdpp) from C++ to rust.
+//!
+//! Currently, this should be viewed as **experimental**.
+//!
+//! # Differences from [tskit](https://tskit.readthedocs.io)
+//!
+//! The tables model differs from `tskit` in some important ways:
+//!
+//! 1. Time moves from the past to the present.
+//!    Thus, child nodes have time values *greater than*
+//!    those of their parents.
+//! 2. The data layout is "array of structures" while
+//!    `tskit` is a "structure of arrays".
+//! 3. Metadata is not part of the tables.
+//!    Often, what one thinks of as metadata is data
+//!    used during the simulation.  Thus, it is not
+//!    part of a [``TableCollection``] and is something
+//!    that would only be useful to write when transfering
+//!    final results ot a [``tskit_rust::TableCollection``].
+//! 4. Mutation table data are different. See [``MutationRecord``].
+//!
+//! # Where to find examples
+//!
+//! The [repository](https://github.com/molpopgen/forrustts)
+//! contains a "sub-crate" of examples, called `forrustts_examples`.
+//!
+//! The source code of the [``wright_fisher``] module contains a full
+//! example of Wright-Fisher simulation with recombination and overlapping.
+//! generations.
+
+// NOTE: uncomment the next line in order to find
+// stuff that needs documenting:
+// #![warn(missing_docs)]
+
 mod edge_buffer;
 mod error;
 pub mod nested_forward_list;
@@ -19,14 +59,14 @@ pub use simplification_buffers::SimplificationBuffers;
 pub use simplification_flags::SimplificationFlags;
 pub use simplification_output::SimplificationOutput;
 pub use simplify_from_edge_buffer::simplify_from_edge_buffer;
-pub use simplify_tables::{simplify_tables, simplify_tables_with_buffers};
+pub use simplify_tables::{simplify_tables, simplify_tables_without_state};
 pub use tables::*;
 pub use tsdef::*;
 
 pub mod tskit;
 pub mod wright_fisher;
 
-/// Get the tskit_rust version number.
+/// Get the forrustts version number.
 pub fn version() -> &'static str {
     return env!("CARGO_PKG_VERSION");
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,13 +1,24 @@
 use crate::tsdef::{IdType, Position};
 
+/// A segment is a half-open
+/// interval of [``crate::Position``]s
+/// associated with a [``crate::Node``].
+///
+/// This type is public primarily because
+/// it is the value element of a
+/// [``crate::EdgeBuffer``].
 #[derive(Clone, Copy)]
 pub struct Segment {
+    /// Left edge of interval
     pub left: Position,
+    /// Right edge of interval
     pub right: Position,
+    /// The node
     pub node: IdType,
 }
 
 impl Segment {
+    /// Create a new instance.
     pub fn new(left: Position, right: Position, node: IdType) -> Self {
         Segment { left, right, node }
     }

--- a/src/simplification_common.rs
+++ b/src/simplification_common.rs
@@ -59,7 +59,7 @@ pub fn process_parent(
         &tables.edges_,
         edge_index,
         num_edges,
-        tables.get_length(),
+        tables.genome_length(),
         u,
         &mut state.ancestry,
         &mut state.overlapper,
@@ -67,7 +67,7 @@ pub fn process_parent(
 
     simplification_logic::merge_ancestors(
         &tables.nodes_,
-        tables.get_length(),
+        tables.genome_length(),
         u,
         state,
         &mut output.idmap,

--- a/src/simplification_flags.rs
+++ b/src/simplification_flags.rs
@@ -15,6 +15,7 @@ bitflags! {
     /// ```
     #[derive(Default)]
     pub struct SimplificationFlags: u32 {
+        /// Placeholder
         const NONE = 0;
     }
 }

--- a/src/simplification_logic.rs
+++ b/src/simplification_logic.rs
@@ -363,7 +363,7 @@ pub fn record_sample_nodes(
         add_ancestry(
             *sample,
             0,
-            tables.get_length(),
+            tables.genome_length(),
             (new_nodes.len() - 1) as IdType,
             ancestry,
         )?;

--- a/src/simplification_output.rs
+++ b/src/simplification_output.rs
@@ -1,3 +1,5 @@
+/// Useful information output by table
+/// simplification.
 pub struct SimplificationOutput {
     /// Maps input node ID to output ID.
     /// Values are set to [``NULL_ID``](crate::NULL_ID)
@@ -6,6 +8,7 @@ pub struct SimplificationOutput {
 }
 
 impl SimplificationOutput {
+    /// Create a new instance.
     pub fn new() -> Self {
         SimplificationOutput { idmap: vec![] }
     }

--- a/src/simplify_from_edge_buffer.rs
+++ b/src/simplify_from_edge_buffer.rs
@@ -124,6 +124,27 @@ fn process_births_from_buffer(
     })?)
 }
 
+/// Simplify a [``TableCollection``] from an [``EdgeBuffer``].
+///
+/// See [``EdgeBuffer``] for discussion.
+///
+/// # Parameters
+///
+/// * `samples`:
+/// * `alive_at_last_simplification`:
+/// * `flags`: modify the behavior of the simplification algorithm.
+/// * `state`: These are the internal data structures used
+///            by the simpilfication algorithm.
+/// * `edge_buffer`: An [``EdgeBuffer``] recording births since the last
+///                  simplification.
+/// * `tables`: a [``TableCollection``] to simplify.
+/// * `output`: Where simplification output gets written.
+///             See [``SimplificationOutput``].
+///
+/// # Notes
+///
+/// The input tables must be sorted.
+/// See [``TableCollection::sort_tables_for_simplification``].
 pub fn simplify_from_edge_buffer(
     samples: &[IdType],
     alive_at_last_simplification: &[IdType],
@@ -150,10 +171,10 @@ pub fn simplify_from_edge_buffer(
         {
             state.overlapper.clear_queue();
             process_births_from_buffer(head, edge_buffer, state)?;
-            state.overlapper.finalize_queue(tables.get_length());
+            state.overlapper.finalize_queue(tables.genome_length());
             simplification_logic::merge_ancestors(
                 &tables.nodes(),
-                tables.get_length(),
+                tables.genome_length(),
                 head,
                 state,
                 &mut output.idmap,
@@ -224,10 +245,10 @@ pub fn simplify_from_edge_buffer(
             }
         }
         process_births_from_buffer(ex.parent, edge_buffer, state)?;
-        state.overlapper.finalize_queue(tables.get_length());
+        state.overlapper.finalize_queue(tables.genome_length());
         simplification_logic::merge_ancestors(
             &tables.nodes_,
-            tables.get_length(),
+            tables.genome_length(),
             ex.parent,
             state,
             &mut output.idmap,

--- a/src/simplify_tables.rs
+++ b/src/simplify_tables.rs
@@ -6,17 +6,56 @@ use crate::SimplificationBuffers;
 use crate::SimplificationFlags;
 use crate::SimplificationOutput;
 
-pub fn simplify_tables(
+/// Simplify a [``TableCollection``].
+///
+/// # Parameters
+///
+/// * `samples`:
+/// * `flags`: modify the behavior of the simplification algorithm.
+/// * `tables`: a [``TableCollection``] to simplify.
+/// * `output`: Where simplification output gets written.
+///             See [``SimplificationOutput``].
+///
+/// # Notes
+///
+/// The input tables must be sorted.
+/// See [``TableCollection::sort_tables_for_simplification``].
+///
+/// It is common to simplify many times during a simulation.
+/// To avoid making big allocations each time, see
+/// [``simplify_tables``] to keep memory allocations
+/// persistent between simplifications.
+pub fn simplify_tables_without_state(
     samples: &[IdType],
     flags: SimplificationFlags,
     tables: &mut TableCollection,
     output: &mut SimplificationOutput,
 ) -> Result<(), ForrusttsError> {
     let mut state = SimplificationBuffers::new();
-    simplify_tables_with_buffers(samples, flags, &mut state, tables, output)
+    simplify_tables(samples, flags, &mut state, tables, output)
 }
 
-pub fn simplify_tables_with_buffers(
+/// Simplify a [``TableCollection``].
+///
+/// This differs from [``simplify_tables_without_state``] in that the big memory
+/// allocations made during simplification are preserved in
+/// an instance of [``SimplificationBuffers``].
+///
+/// # Parameters
+///
+/// * `samples`:
+/// * `flags`: modify the behavior of the simplification algorithm.
+/// * `state`: These are the internal data structures used
+///            by the simpilfication algorithm.
+/// * `tables`: a [``TableCollection``] to simplify.
+/// * `output`: Where simplification output gets written.
+///             See [``SimplificationOutput``].
+///
+/// # Notes
+///
+/// The input tables must be sorted.
+/// See [``TableCollection::sort_tables_for_simplification``].
+pub fn simplify_tables(
     samples: &[IdType],
     flags: SimplificationFlags,
     state: &mut SimplificationBuffers,

--- a/src/test_simplify_tables.rs
+++ b/src/test_simplify_tables.rs
@@ -4,7 +4,7 @@ mod test {
     // stuff from tskit_rust and forrusts, which isn't great.
     // We'll clean this up later when we get better abstractions
     // into tskit_rust.
-    use crate::simplify_tables;
+    use crate::simplify_tables_without_state;
     use crate::tsdef::{IdType, Position, Time};
     use crate::wright_fisher::*;
     use crate::ForrusttsError;
@@ -48,7 +48,7 @@ mod test {
                 littler: 5e-3,
                 psurvival,
             },
-            SimulationParameters {
+            SimulationParams {
                 simplification_interval,
                 seed,
                 nsteps: num_generations,
@@ -97,7 +97,7 @@ mod test {
         }
 
         let mut output = SimplificationOutput::new();
-        simplify_tables(
+        simplify_tables_without_state(
             &samples,
             SimplificationFlags::empty(),
             &mut tables,

--- a/src/tskit.rs
+++ b/src/tskit.rs
@@ -1,4 +1,13 @@
 //! Data interchange to ``tskit`` format using [``tskit_rust``].
+//!
+//! # Note
+//!
+//! This module may be prone to API-breaking changes!
+//! Currently, the function implementations are the minimum
+//! needed for testing/data exchange.
+//!
+//! As things develop, we may either add new functions or
+//! refactor the existing.
 
 use crate::tsdef::Time;
 use crate::TableCollection;
@@ -58,7 +67,7 @@ pub fn convert_to_tskit(
     convert_time: impl Fn(Time) -> f64,
     build_indexes: bool,
 ) -> tskit_rust::TableCollection {
-    let mut tsk_tables = tskit_rust::TableCollection::new(tables.get_length() as f64).unwrap();
+    let mut tsk_tables = tskit_rust::TableCollection::new(tables.genome_length() as f64).unwrap();
 
     for e in tables.edges() {
         tsk_tables
@@ -152,7 +161,7 @@ pub fn convert_to_tskit_and_drain(
     build_indexes: bool,
     tables: &mut TableCollection,
 ) -> tskit_rust::TableCollection {
-    let mut tsk_tables = tskit_rust::TableCollection::new(tables.get_length() as f64).unwrap();
+    let mut tsk_tables = tskit_rust::TableCollection::new(tables.genome_length() as f64).unwrap();
 
     let mut max_pop: tsk_id_t = -1;
     for (i, n) in tables.enumerate_nodes() {


### PR DESCRIPTION
Big documentation push.  We'll use this to also clean up API and behavior issues that doc writing reveals.

- [x] Add README
- [x] Remove the 'warn if not documented' thing.
- [x] Describe differences from tskit in the module docs.
- [x] Refer to wright_fisher module in module docs as source for a very detailed example.
- [x] Document that the `tskit` module is prone to API-breaking changes until metadata stuff is sorted.
