### PR TITLE
Use slices instead of references to vectors.

### DIFF
--- a/src/tables.rs
+++ b/src/tables.rs
@@ -243,10 +243,7 @@ fn mutation_table_add_row(
     Ok((mutations.len() - 1) as IdType)
 }
 
-fn sort_edge_table(nodes: &[Node], edges: &mut [Edge]) {
-    // NOTE: it may by more idiomatic to
-    // not use a slice here, and instead allow
-    // the range-checking?
+fn sort_edges(nodes: &[Node], edges: &mut [Edge]) {
     edges.sort_by(|a, b| {
         let aindex = a.parent as usize;
         let bindex = b.parent as usize;
@@ -700,7 +697,7 @@ impl TableCollection {
     /// Sort all tables for simplification.
     pub fn sort_tables(&mut self, flags: TableSortingFlags) {
         if !flags.contains(TableSortingFlags::SKIP_EDGE_TABLE) {
-            sort_edge_table(&self.nodes_, &mut self.edges_);
+            sort_edges(&self.nodes_, &mut self.edges_);
         }
         sort_mutation_table(&self.sites_, &mut self.mutations_);
     }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -243,7 +243,7 @@ fn mutation_table_add_row(
     Ok((mutations.len() - 1) as IdType)
 }
 
-fn sort_edge_table(nodes: &[Node], edges: &mut EdgeTable) {
+fn sort_edge_table(nodes: &[Node], edges: &mut [Edge]) {
     // NOTE: it may by more idiomatic to
     // not use a slice here, and instead allow
     // the range-checking?
@@ -265,7 +265,7 @@ fn sort_edge_table(nodes: &[Node], edges: &mut EdgeTable) {
     });
 }
 
-fn sort_mutation_table(sites: &[Site], mutations: &mut MutationTable) {
+fn sort_mutation_table(sites: &[Site], mutations: &mut [MutationRecord]) {
     mutations.sort_by(|a, b| {
         let pa = sites[a.site].position;
         let pb = sites[b.site].position;
@@ -622,12 +622,12 @@ impl TableCollection {
     }
 
     /// Return immutable reference to the [mutation table](type.MutationTable.html)
-    pub fn mutations(&self) -> &MutationTable {
+    pub fn mutations(&self) -> &[MutationRecord] {
         &self.mutations_
     }
 
     /// Return immutable reference to the [edge table](type.EdgeTable.html)
-    pub fn edges(&self) -> &EdgeTable {
+    pub fn edges(&self) -> &[Edge] {
         &self.edges_
     }
 
@@ -642,7 +642,7 @@ impl TableCollection {
     }
 
     /// Return immutable reference to [node table](type.NodeTable.html)
-    pub fn nodes(&self) -> &NodeTable {
+    pub fn nodes(&self) -> &[Node] {
         &self.nodes_
     }
 
@@ -667,7 +667,7 @@ impl TableCollection {
     }
 
     /// Return immutable reference to [site table](type.SiteTable.html)
-    pub fn sites(&self) -> &SiteTable {
+    pub fn sites(&self) -> &[Site] {
         &self.sites_
     }
 

--- a/src/tskit_tools.rs
+++ b/src/tskit_tools.rs
@@ -157,11 +157,6 @@ fn swap_with_empty<T>(v: &mut Vec<T>) {
 /// // The input tables have no data:
 /// assert_eq!(tables.num_nodes(), 0);
 /// assert_eq!(tables.num_edges(), 0);
-/// // The memory has been returned to the system,
-/// // and the internal containers have no allocated
-/// // capacity:
-/// assert_eq!(tables.nodes().capacity(), 0);
-/// assert_eq!(tables.edges().capacity(), 0);
 /// ```
 pub fn convert_to_tskit_and_drain_minimal(
     is_sample: &[i32],
@@ -201,6 +196,9 @@ pub fn convert_to_tskit_and_drain_minimal(
     if build_indexes {
         tsk_tables.build_index().unwrap();
     }
+
+    assert_eq!(tables.nodes_.capacity(), 0);
+    assert_eq!(tables.edges_.capacity(), 0);
 
     tsk_tables
 }


### PR DESCRIPTION
Improves generality of the API for cases where we are not adding/removing from tables.