### PR TITLE
Expand the trees API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,13 @@ pub enum ForrusttsError {
         #[from]
         value: crate::TablesError,
     },
+    /// A redirection of a [``crate::TreesError``]
+    #[error("{value:?}")]
+    TreesError {
+        /// The redirected error
+        #[from]
+        value: crate::TreesError,
+    },
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 // stuff that needs documenting:
 // #![warn(missing_docs)]
 
+mod macros;
+
 mod error;
 pub mod nested_forward_list;
 mod segment;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,13 @@
+#![macro_use]
+
+macro_rules! iterator_for_nodeiterator {
+    ($ty: ty) => {
+        impl Iterator for $ty {
+            type Item = $crate::IdType;
+            fn next(&mut self) -> Option<Self::Item> {
+                self.next_node();
+                self.current_node()
+            }
+        }
+    };
+}

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1,4 +1,4 @@
-use crate::{IdType, IdVec, Position, NULL_ID};
+use crate::{IdType, IdVec, Position, Time, NULL_ID};
 use bitflags::bitflags;
 
 bitflags! {
@@ -37,13 +37,230 @@ impl Default for TopologyData {
     }
 }
 
+trait NodeIterator {
+    fn next_node(&mut self);
+    fn current_node(&mut self) -> Option<IdType>;
+}
+
+/// Specify the traversal order used by
+/// [`Tree::traverse_nodes`].
+pub enum NodeTraversalOrder {
+    ///Preorder traversal, starting at the root(s) of a [`Tree`].
+    ///For trees with multiple roots, start at the left root,
+    ///traverse to tips, proceeed to the next root, etc..
+    Preorder,
+}
+
+struct PreorderNodeIterator<'a> {
+    root_stack: Vec<IdType>,
+    node_stack: Vec<IdType>,
+    tree: &'a Tree<'a>,
+    current_node_: Option<IdType>,
+}
+
+impl<'a> PreorderNodeIterator<'a> {
+    fn new(tree: &'a Tree) -> Self {
+        let mut rv = PreorderNodeIterator {
+            root_stack: tree.roots_to_vec(),
+            node_stack: vec![],
+            tree,
+            current_node_: None,
+        };
+        rv.root_stack.reverse();
+        if let Some(root) = rv.root_stack.pop() {
+            rv.node_stack.push(root);
+        }
+        rv
+    }
+}
+
+impl NodeIterator for PreorderNodeIterator<'_> {
+    fn next_node(&mut self) {
+        self.current_node_ = self.node_stack.pop();
+        match self.current_node_ {
+            Some(u) => {
+                let mut c = self.tree.left_child(u).unwrap();
+                while c != NULL_ID {
+                    self.node_stack.push(c);
+                    c = self.tree.right_sib(c).unwrap();
+                }
+            }
+            None => {
+                if let Some(r) = self.root_stack.pop() {
+                    self.current_node_ = Some(r);
+                }
+            }
+        };
+    }
+
+    fn current_node(&mut self) -> Option<IdType> {
+        self.current_node_
+    }
+}
+
+iterator_for_nodeiterator!(PreorderNodeIterator<'_>);
+
+struct RootIterator<'a> {
+    current_root: Option<IdType>,
+    next_root: IdType,
+    tree: &'a Tree<'a>,
+}
+
+impl<'a> RootIterator<'a> {
+    fn new(tree: &'a Tree) -> Self {
+        RootIterator {
+            current_root: None,
+            next_root: tree.left_root,
+            tree,
+        }
+    }
+}
+
+impl NodeIterator for RootIterator<'_> {
+    fn next_node(&mut self) {
+        self.current_root = match self.next_root {
+            NULL_ID => None,
+            r => {
+                assert!(r >= 0);
+                let cr = Some(r);
+                self.next_root = self.tree.right_sib(r).unwrap();
+                cr
+            }
+        };
+    }
+
+    fn current_node(&mut self) -> Option<IdType> {
+        self.current_root
+    }
+}
+
+iterator_for_nodeiterator!(RootIterator<'_>);
+
+struct ChildIterator<'a> {
+    current_child: Option<IdType>,
+    next_child: IdType,
+    tree: &'a Tree<'a>,
+}
+
+impl<'a> ChildIterator<'a> {
+    fn new(tree: &'a Tree, u: IdType) -> Self {
+        let c = tree.left_child(u).unwrap();
+
+        ChildIterator {
+            current_child: None,
+            next_child: c,
+            tree,
+        }
+    }
+}
+
+impl NodeIterator for ChildIterator<'_> {
+    fn next_node(&mut self) {
+        self.current_child = match self.next_child {
+            NULL_ID => None,
+            r => {
+                assert!(r >= 0);
+                let cr = Some(r);
+                self.next_child = self.tree.right_sib(r).unwrap();
+                cr
+            }
+        };
+    }
+
+    fn current_node(&mut self) -> Option<IdType> {
+        self.current_child
+    }
+}
+
+iterator_for_nodeiterator!(ChildIterator<'_>);
+
+struct ParentsIterator<'a> {
+    current_node: Option<IdType>,
+    next_node: IdType,
+    tree: &'a Tree<'a>,
+}
+
+impl<'a> ParentsIterator<'a> {
+    fn new(tree: &'a Tree, u: IdType) -> Self {
+        ParentsIterator {
+            current_node: None,
+            next_node: u,
+            tree,
+        }
+    }
+}
+
+impl NodeIterator for ParentsIterator<'_> {
+    fn next_node(&mut self) {
+        self.current_node = match self.next_node {
+            NULL_ID => None,
+            r => {
+                assert!(r >= 0);
+                let cr = Some(r);
+                self.next_node = self.tree.parent(r).unwrap();
+                cr
+            }
+        };
+    }
+
+    fn current_node(&mut self) -> Option<IdType> {
+        self.current_node
+    }
+}
+
+iterator_for_nodeiterator!(ParentsIterator<'_>);
+
+struct SamplesIterator<'a> {
+    current_node: Option<IdType>,
+    next_sample_index: IdType,
+    last_sample_index: IdType,
+    tree: &'a Tree<'a>,
+}
+
+impl<'a> SamplesIterator<'a> {
+    fn new(tree: &'a Tree, u: IdType) -> Self {
+        SamplesIterator {
+            current_node: None,
+            next_sample_index: tree.left_sample(u).unwrap(),
+            last_sample_index: tree.right_sample(u).unwrap(),
+            tree,
+        }
+    }
+}
+
+impl NodeIterator for SamplesIterator<'_> {
+    fn next_node(&mut self) {
+        self.current_node = match self.next_sample_index {
+            NULL_ID => None,
+            r => {
+                if r == self.last_sample_index {
+                    let cr = Some(self.tree.samples[r as usize]);
+                    self.next_sample_index = NULL_ID;
+                    cr
+                } else {
+                    assert!(r >= 0);
+                    let cr = Some(self.tree.samples[r as usize]);
+                    self.next_sample_index = self.tree.topology[r as usize].next_sample;
+                    cr
+                }
+            }
+        };
+    }
+
+    fn current_node(&mut self) -> Option<IdType> {
+        self.current_node
+    }
+}
+
+iterator_for_nodeiterator!(SamplesIterator<'_>);
+
 pub struct Tree<'treeseq> {
     topology: Vec<TopologyData>,
     left_root: IdType,
     above_sample: Vec<i8>,
     left: Position,
     right: Position,
-    samples: IdVec,
+    samples: &'treeseq [IdType],
     sample_index_map: IdVec, // TODO: decide if this is better as usize.
     flags: TreeFlags,
     treeseq: &'treeseq TreeSequence<'treeseq>,
@@ -55,14 +272,14 @@ pub struct Tree<'treeseq> {
 }
 
 impl<'treeseq> Tree<'treeseq> {
-    fn new_internal(treeseq: &'treeseq TreeSequence, samples: &[IdType], flags: TreeFlags) -> Self {
+    fn new_internal(treeseq: &'treeseq TreeSequence, flags: TreeFlags) -> Self {
         Self {
             topology: vec![TopologyData::default(); treeseq.tables.num_nodes()],
             left_root: NULL_ID,
             above_sample: vec![0; treeseq.tables.num_nodes()],
             left: Position::MIN,
             right: Position::MIN,
-            samples: samples.to_vec(),
+            samples: treeseq.samples.as_slice(),
             sample_index_map: vec![NULL_ID; treeseq.tables.num_nodes()],
             flags,
             treeseq,
@@ -76,7 +293,7 @@ impl<'treeseq> Tree<'treeseq> {
     fn init_samples(&mut self) {
         for (i, s) in self.samples.iter().enumerate() {
             if self.sample_index_map[*s as usize] != NULL_ID {
-                panic!("invalid sample list");
+                panic!("Duplicate samples passed to Tree!");
             }
             self.sample_index_map[*s as usize] = i as IdType;
             if let Some(row) = self.topology.get_mut(*s as usize) {
@@ -260,12 +477,179 @@ impl<'treeseq> Tree<'treeseq> {
         }
     }
 
-    pub fn new(treeseq: &'treeseq TreeSequence, samples: &[IdType], flags: TreeFlags) -> Self {
-        assert!(!samples.is_empty());
-        let mut rv = Self::new_internal(treeseq, samples, flags);
+    fn id_in_range(&self, u: IdType) -> TreesResult<()> {
+        if u < 0 || (u as usize) >= self.num_nodes() {
+            Err(TreesError::NodeIdOutOfRange)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn new(treeseq: &'treeseq TreeSequence, flags: TreeFlags) -> Self {
+        let mut rv = Self::new_internal(treeseq, flags);
         rv.init_samples();
         rv.left_root = rv.samples[0];
         rv
+    }
+
+    /// Return an [`Iterator`] over all nodes in the tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `order`: A value from [`NodeTraversalOrder`] specifying the
+    ///   iteration order.
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    // Return value is dyn for later addition of other traversal orders
+    // FIXME This should be allowed to error
+    pub fn traverse_nodes(
+        &self,
+        order: NodeTraversalOrder,
+    ) -> Box<dyn Iterator<Item = IdType> + '_> {
+        match order {
+            NodeTraversalOrder::Preorder => Box::new(PreorderNodeIterator::new(&self)),
+        }
+    }
+
+    pub fn span(&self) -> Position {
+        self.right - self.left
+    }
+
+    /// Calculate the total length of the tree via a preorder traversal.
+    ///
+    /// # Parameters
+    ///
+    /// * `by_span`: if `true`, multiply the return value by [`Tree::span`].
+    pub fn total_branch_length(&self, by_span: bool) -> Result<Time, TreesError> {
+        let nt = self.treeseq.tables.nodes_.as_slice();
+        let mut b = 0;
+        for n in self.traverse_nodes(NodeTraversalOrder::Preorder) {
+            let p = self.parent(n)?;
+            if p != NULL_ID {
+                b += nt[n as usize].time - nt[p as usize].time;
+            }
+        }
+
+        match by_span {
+            true => Ok(b * self.span()),
+            false => Ok(b),
+        }
+    }
+
+    /// Return an [`Iterator`] from the node `u` to the root of the tree,
+    /// travering all parent nodes.
+    ///
+    /// # Errors
+    ///
+    /// [`TreesError::NodeIdOutOfRange`] if `u` is out of range.
+    pub fn parents(&self, u: IdType) -> Result<impl Iterator<Item = IdType> + '_, TreesError> {
+        self.id_in_range(u)?;
+        Ok(ParentsIterator::new(self, u))
+    }
+
+    /// Return an [`Iterator`] over the children of node `u`.
+    ///
+    /// # Errors
+    ///
+    /// [`TreesError::NodeIdOutOfRange`] if `u` is out of range.
+    pub fn children(&self, u: IdType) -> Result<impl Iterator<Item = IdType> + '_, TreesError> {
+        self.id_in_range(u)?;
+        Ok(ChildIterator::new(&self, u))
+    }
+
+    /// Return an [`Iterator`] over the roots of the tree.
+    ///
+    /// # Note
+    ///
+    /// For a tree with multiple roots, the iteration starts
+    /// at the left root.
+    pub fn roots(&self) -> impl Iterator<Item = IdType> + '_ {
+        RootIterator::new(self)
+    }
+
+    /// Return all roots as a vector.
+    pub fn roots_to_vec(&self) -> Vec<IdType> {
+        let mut v = vec![];
+
+        for r in self.roots() {
+            v.push(r);
+        }
+
+        v
+    }
+
+    pub fn sample_nodes(&self) -> &[IdType] {
+        &self.samples
+    }
+
+    /// Return an [`Iterator`] over the sample nodes descending from node `u`.
+    ///
+    ///
+    /// # Note
+    ///
+    /// If `u` is itself a sample, then it is included in the values returned.
+    ///
+    /// # Errors
+    ///
+    /// [`TreesError::NodeIdOutOfRange`] if `u` is out of range.
+    ///
+    /// [`TreesError::NotTrackingSamples`] if [`TreeFlags::TRACK_SAMPLES`] was not used
+    /// to initialize `self`.
+    pub fn samples(&self, u: IdType) -> Result<impl Iterator<Item = IdType> + '_, TreesError> {
+        if !self.flags.contains(TreeFlags::TRACK_SAMPLES) {
+            Err(TreesError::NotTrackingSamples)
+        } else {
+            Ok(SamplesIterator::new(self, u))
+        }
+    }
+
+    pub fn num_nodes(&self) -> usize {
+        assert_eq!(self.topology.len(), self.treeseq.tables.num_nodes());
+        self.treeseq.tables.num_nodes()
+    }
+
+    pub fn parent(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.parent)
+    }
+
+    pub fn left_child(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.left_child)
+    }
+
+    pub fn right_child(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.right_child)
+    }
+
+    pub fn left_sib(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.left_sib)
+    }
+
+    pub fn right_sib(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.right_sib)
+    }
+
+    pub fn left_sample(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.left_sample)
+    }
+
+    pub fn right_sample(&self, u: IdType) -> TreesResult<IdType> {
+        self.id_in_range(u)?;
+        // SAFETY: just checked the range.
+        Ok(unsafe { self.topology.get_unchecked(u as usize) }.right_sample)
     }
 }
 
@@ -273,16 +657,19 @@ impl<'treeseq> Tree<'treeseq> {
 impl<'treeseq> streaming_iterator::StreamingIterator for Tree<'treeseq> {
     type Item = Tree<'treeseq>;
 
+    // TODO: if tables are validated when TreeSequence is created,
+    // then the accesses below can be unchecked.
     fn advance(&mut self) {
-        let tables = &self.treeseq.tables;
+        let tables = self.treeseq.tables;
         let edge_table = self.treeseq.tables.edges_.as_slice();
         let edge_input_order = tables.edge_input_order.as_slice();
         let edge_output_order = tables.edge_output_order.as_slice();
         if self.input_edge_index < edge_input_order.len() || self.x < tables.genome_length() {
-            while self.output_edge_index < edge_output_order.len()
-                && edge_table[edge_output_order[self.output_edge_index]].right == self.x
-            {
-                let current_edge = edge_table[edge_output_order[self.output_edge_index]];
+            for edge_index in edge_output_order[self.output_edge_index..].iter() {
+                let current_edge = edge_table[*edge_index];
+                if current_edge.right != self.x {
+                    break;
+                }
                 let lsib = self.topology[current_edge.child as usize].left_sib;
                 let rsib = self.topology[current_edge.child as usize].right_sib;
 
@@ -309,10 +696,11 @@ impl<'treeseq> streaming_iterator::StreamingIterator for Tree<'treeseq> {
                 self.update_outgoing_roots(current_edge.parent, current_edge.child);
                 self.output_edge_index += 1;
             }
-            while self.input_edge_index < edge_input_order.len()
-                && edge_table[edge_input_order[self.input_edge_index]].left == self.x
-            {
-                let current_edge = edge_table[edge_input_order[self.input_edge_index]];
+            for edge_index in edge_input_order[self.input_edge_index..].iter() {
+                let current_edge = edge_table[*edge_index];
+                if current_edge.left != self.x {
+                    break;
+                }
                 let rchild = self.topology[current_edge.parent as usize].right_child;
                 let lsib = self.topology[current_edge.child as usize].left_sib;
                 let rsib = self.topology[current_edge.child as usize].right_sib;
@@ -383,38 +771,159 @@ pub enum TreesError {
     /// Raised by [``TreeSequence::new``].
     #[error("Tables not indexed.")]
     TablesNotIndexed,
+    #[error("Node ID out of range")]
+    NodeIdOutOfRange,
+    #[error("No samples found.")]
+    NoSamples,
+    #[error("Invalid samples.")]
+    InvalidSamples,
+    #[error("Duplicate samples.")]
+    DuplicateSamples,
+    #[error("Not tracking samples.")]
+    NotTrackingSamples,
 }
 
 pub struct TreeSequence<'a> {
     tables: &'a crate::TableCollection,
+    samples: IdVec,
+    num_trees: i32,
 }
 
 /// Result type for operations on trees and tree sequences.
 pub type TreesResult<T> = Result<T, TreesError>;
 
+bitflags! {
+    pub struct TreeSequenceFlags: u32 {
+        /// Do not validate tables when creating a [`TreeSequence`]
+        const NO_TABLE_VALIDATION = 1 << 0;
+    }
+}
+
 impl<'a> TreeSequence<'a> {
-    pub fn new(tables: &'a crate::TableCollection) -> TreesResult<Self> {
-        Ok(Self { tables })
+    fn new_from_tables(
+        tables: &'a crate::TableCollection,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if !tables.is_indexed() {
+            return Err(Box::new(crate::TablesError::TablesNotIndexed));
+        }
+        let mut samples = vec![];
+        for (i, n) in tables.nodes_.iter().enumerate() {
+            if n.flags & crate::NodeFlags::IS_SAMPLE.bits() > 0 {
+                samples.push(i as IdType);
+            }
+        }
+        if samples.is_empty() {
+            Err(Box::new(TreesError::NoSamples))
+        } else {
+            Ok(Self {
+                tables,
+                samples,
+                num_trees: tables.count_trees().unwrap(),
+            })
+        }
+    }
+
+    pub fn new(
+        tables: &'a crate::TableCollection,
+        flags: TreeSequenceFlags,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if !tables.is_indexed() {
+            return Err(Box::new(crate::TablesError::TablesNotIndexed));
+        }
+        if !flags.contains(TreeSequenceFlags::NO_TABLE_VALIDATION) {
+            tables.validate(crate::TableValidationFlags::empty())?;
+        }
+        Self::new_from_tables(tables)
+    }
+
+    pub fn new_with_samples(
+        tables: &'a crate::TableCollection,
+        samples: &[IdType],
+        flags: TreeSequenceFlags,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        if !flags.contains(TreeSequenceFlags::NO_TABLE_VALIDATION) {
+            tables.validate(crate::TableValidationFlags::empty())?;
+        }
+        let mut nodes = vec![0; tables.nodes_.len()];
+        for s in samples {
+            if *s == NULL_ID {
+                return Err(Box::new(TreesError::InvalidSamples));
+            }
+            if nodes[*s as usize] != 0 {
+                return Err(Box::new(TreesError::DuplicateSamples));
+            }
+            nodes[*s as usize] = 1;
+        }
+        for n in tables.nodes_.iter() {
+            if n.flags | crate::NodeFlags::IS_SAMPLE.bits() > 0 {
+                return Err(Box::new(TreesError::InvalidSamples));
+            }
+        }
+        Ok(Self {
+            tables,
+            samples: samples.to_vec(),
+            num_trees: tables.count_trees().unwrap(),
+        })
     }
 
     pub fn tables(&self) -> &'a crate::TableCollection {
         self.tables
     }
 
-    pub fn tree_iter(&self, samples: &[IdType], flags: TreeFlags) -> Tree<'_> {
-        Tree::new(self, samples, flags)
+    pub fn tree_iter(&self, flags: TreeFlags) -> Tree<'_> {
+        Tree::new(self, flags)
+    }
+
+    pub fn sample_nodes(&self) -> &[IdType] {
+        &self.samples
+    }
+
+    pub fn num_trees(&self) -> i32 {
+        self.num_trees
+    }
+
+    pub fn simplify(
+        &self,
+        samples: Option<&[IdType]>,
+        flags: crate::SimplificationFlags,
+    ) -> Result<(crate::TableCollection, crate::SimplificationOutput), crate::ForrusttsError> {
+        let mut tcopy = self.tables.clone();
+        let mut si = crate::SamplesInfo::new();
+        match samples {
+            Some(x) => si.samples = x.to_vec(),
+            None => {
+                for (i, n) in self.tables.nodes_.iter().enumerate() {
+                    if n.flags | crate::NodeFlags::IS_SAMPLE.bits() > 0 {
+                        si.samples.push(i as IdType);
+                    }
+                }
+            }
+        }
+        let mut output = crate::SimplificationOutput::default();
+        crate::simplify_tables_without_state(&si, flags, &mut tcopy, &mut output)?;
+        Ok((tcopy, output))
     }
 }
 
+// FIXME: these tests are weak.
+// We'd be better with a light simulator + direct comparison to tskit.
 #[cfg(test)]
 mod test_trees {
+    use super::*;
 
     #[test]
     fn test_treeseq_creation_and_table_access() {
         let mut tables = crate::TableCollection::new(100).unwrap();
+        tables.add_node(0, 0).unwrap();
+        tables
+            .add_node_with_flags(1, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
         tables.add_edge(0, 1, 0, 1).unwrap();
+        tables
+            .build_indexes(crate::IndexTablesFlags::empty())
+            .unwrap();
 
-        let ts = super::TreeSequence::new(&tables).unwrap();
+        let ts = TreeSequence::new(&tables, TreeSequenceFlags::empty()).unwrap();
 
         let tref = ts.tables();
         assert_eq!(tref.edges().len(), 1);
@@ -424,14 +933,19 @@ mod test_trees {
     fn test_treeseq_creation_and_tree_creation() {
         let mut tables = crate::TableCollection::new(100).unwrap();
         tables.add_edge(0, 1, 0, 1).unwrap();
-        tables.add_node(0, 0).unwrap();
+        tables
+            .add_node_with_flags(0, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
         tables.add_node(1, 0).unwrap();
+        tables
+            .build_indexes(crate::IndexTablesFlags::empty())
+            .unwrap();
 
-        let ts = super::TreeSequence::new(&tables).unwrap();
-        let _ = ts.tree_iter(&[0], super::TreeFlags::empty());
+        let ts = TreeSequence::new(&tables, TreeSequenceFlags::empty()).unwrap();
+        let _ = ts.tree_iter(TreeFlags::empty());
     }
 
-    fn make_small_table_collection_two_trees() -> crate::TableCollection {
+    pub fn make_small_table_collection_two_trees() -> crate::TableCollection {
         // The two trees are:
         //  0
         // +++
@@ -448,10 +962,18 @@ mod test_trees {
         let mut tables = crate::TableCollection::new(1000).unwrap();
         tables.add_node(0, 0).unwrap();
         tables.add_node(1, 0).unwrap();
-        tables.add_node(2, 0).unwrap(); // nodes 2-5 are samples
-        tables.add_node(2, 0).unwrap();
-        tables.add_node(2, 0).unwrap();
-        tables.add_node(2, 0).unwrap();
+        tables
+            .add_node_with_flags(2, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
+        tables
+            .add_node_with_flags(2, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
+        tables
+            .add_node_with_flags(2, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
+        tables
+            .add_node_with_flags(2, 0, crate::NodeFlags::IS_SAMPLE.bits())
+            .unwrap();
         tables.add_edge(500, 1000, 0, 1).unwrap();
         tables.add_edge(0, 500, 0, 2).unwrap();
         tables.add_edge(0, 1000, 0, 3).unwrap();
@@ -465,21 +987,166 @@ mod test_trees {
         tables
             .build_indexes(crate::IndexTablesFlags::empty())
             .unwrap();
+        assert_eq!(tables.count_trees().unwrap(), 2);
         tables
     }
 
+    // FIXME: this test is UGLY
+    // 1. too much repetition.
+    // 2. We should be making loads of random toplogies
+    //    and comparing to tskit.
     #[test]
     fn test_two_trees() {
         use streaming_iterator::StreamingIterator;
         let tables = make_small_table_collection_two_trees();
-        let treeseq = super::TreeSequence::new(&tables).unwrap();
-        let samples: crate::IdVec = vec![2, 3, 4, 5];
+        let treeseq = TreeSequence::new(&tables, TreeSequenceFlags::empty()).unwrap();
+        assert_eq!(treeseq.samples.len(), 4);
 
-        for i in &samples {
-            assert_eq!(tables.node(*i).time, 2);
+        let mut tree_iter = treeseq.tree_iter(TreeFlags::TRACK_SAMPLES);
+        let mut ntrees = 0;
+        while let Some(tree) = tree_iter.next() {
+            if ntrees == 0 {
+                let mut nodes = vec![0; tree.num_nodes()];
+                for c in tree.children(0).unwrap() {
+                    nodes[c as usize] = 1;
+                }
+                assert_eq!(nodes[2], 1);
+                assert_eq!(nodes[3], 1);
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for c in tree.children(1).unwrap() {
+                    nodes[c as usize] = 1;
+                }
+                assert_eq!(nodes[4], 1);
+                assert_eq!(nodes[5], 1);
+
+                for p in tree.parents(2).unwrap() {
+                    nodes[p as usize] = 1;
+                }
+                assert_eq!(nodes[0], 1);
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for p in tree.parents(5).unwrap() {
+                    nodes[p as usize] = 1;
+                }
+                assert_eq!(nodes[1], 1);
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                let roots = tree.roots_to_vec();
+                assert_eq!(roots.len(), 2);
+                for r in &roots {
+                    nodes[*r as usize] = 1;
+                }
+                for i in &[0, 1] {
+                    assert_eq!(nodes[*i as usize], 1);
+                }
+
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for s in tree.samples(0).unwrap() {
+                    nodes[s as usize] = 1;
+                }
+                for i in &[2, 3] {
+                    assert_eq!(nodes[*i as usize], 1);
+                }
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for s in tree.samples(1).unwrap() {
+                    nodes[s as usize] = 1;
+                }
+                for i in &[4, 5] {
+                    assert_eq!(nodes[*i as usize], 1);
+                }
+                for x in &mut nodes {
+                    *x = 0;
+                }
+            } else if ntrees == 1 {
+                let mut nodes = vec![0; tree.num_nodes()];
+                for c in tree.children(0).unwrap() {
+                    nodes[c as usize] = 1;
+                }
+                assert_eq!(nodes[1], 1);
+                assert_eq!(nodes[3], 1);
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for c in tree.children(1).unwrap() {
+                    nodes[c as usize] = 1;
+                }
+                assert_eq!(nodes[2], 1);
+                assert_eq!(nodes[4], 1);
+                assert_eq!(nodes[5], 1);
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                let roots = tree.roots_to_vec();
+                assert_eq!(roots.len(), 1);
+                for r in &roots {
+                    nodes[*r as usize] = 1;
+                }
+                for i in &[0] {
+                    assert_eq!(nodes[*i as usize], 1);
+                }
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for s in tree.samples(0).unwrap() {
+                    nodes[s as usize] = 1;
+                }
+                for s in tree.sample_nodes() {
+                    assert_eq!(nodes[*s as usize], 1);
+                }
+                for x in &mut nodes {
+                    *x = 0;
+                }
+                for s in tree.samples(1).unwrap() {
+                    nodes[s as usize] = 1;
+                }
+                for s in &[2, 4, 5] {
+                    assert_eq!(nodes[*s as usize], 1);
+                }
+            }
+
+            // Check that each sample node contains itself
+            // when iterating over samples.
+            for s in tree.sample_nodes() {
+                for i in tree.samples(*s).unwrap() {
+                    assert_eq!(i, *s);
+                }
+            }
+            ntrees += 1;
         }
+        assert_eq!(ntrees, 2);
+    }
+}
 
-        let mut tree_iter = treeseq.tree_iter(&samples, super::TreeFlags::TRACK_SAMPLES);
+#[cfg(test)]
+mod test_treeseq_encapsulation {
+    use super::*;
+
+    struct MyStruct {
+        tables: crate::TableCollection,
+    }
+
+    impl MyStruct {
+        fn treeseq(&self) -> TreeSequence<'_> {
+            TreeSequence::new(&self.tables, TreeSequenceFlags::empty()).unwrap()
+        }
+    }
+
+    #[test]
+    fn test_create_treeseq() {
+        use streaming_iterator::StreamingIterator;
+        let tables = test_trees::make_small_table_collection_two_trees();
+        let mystruct = MyStruct { tables };
+        let treeseq = mystruct.treeseq();
+
+        let mut tree_iter = treeseq.tree_iter(TreeFlags::TRACK_SAMPLES);
         let mut ntrees = 0;
         while tree_iter.next().is_some() {
             ntrees += 1;

--- a/src/tsdef.rs
+++ b/src/tsdef.rs
@@ -8,4 +8,4 @@ pub type IdVec = Vec<IdType>;
 
 /// Equals -1 (minus one).
 /// Primary use is to indicate a null [Node](struct.Node.html) id.
-pub static NULL_ID: IdType = -1;
+pub const NULL_ID: IdType = -1;


### PR DESCRIPTION
- [x] TreeSequence list of samples
- [x] TreeSequence::new method for a list of samples (useful when node flags not used).
- [x] TreeSequence should error out when tables are not indexed.
- [x] Calculate number of trees when initializing a tree sequence
- [x] TreeSequence init should validate tables by default.
- [x] Add TreeSequence::simplify.
- [x] Preorder node traversal of a tree
- [x] The various "node iterators" a la tskit-rust.
- [x] Replace `panic!` and (most) `assert!` with proper error propagation to `ForrusttsError`.
- [x] Add `TreesError` as a `from` to `ForrusttsErrror`.
- [x] TreeSeq::new_with_samples should validate sample lists.