### PR TITLE
simplify in separate thread

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -1,0 +1,9 @@
+import tskit
+
+a = tskit.load("regular.trees")
+b = tskit.load("consume.trees")
+
+print(a.num_nodes, b.num_nodes)
+print(a.num_edges, b.num_edges)
+
+assert a == b

--- a/forrustts-tables-trees/src/simplification.rs
+++ b/forrustts-tables-trees/src/simplification.rs
@@ -1061,6 +1061,10 @@ pub fn simplify_from_edge_buffer(
 ) -> Result<(), SimplificationError> {
     setup_simplification(samples, tables, flags, state, output)?;
 
+    println!("The samples list is:");
+    for s in samples.samples.iter() {
+        println!("{}", s.0);
+    }
     println!("edge_buffer contents:");
     for (i, p) in edge_buffer.0.head_iter().enumerate() {
         for j in edge_buffer.0.values_iter(i as i32) {
@@ -1068,9 +1072,17 @@ pub fn simplify_from_edge_buffer(
         }
     }
     println!("node IDs alive at last simplification:");
-    for i in samples.edge_buffer_founder_nodes.iter()
-    {
-        println!("{}",i.0);
+    for i in samples.edge_buffer_founder_nodes.iter() {
+        println!("{}", i.0);
+    }
+    println!("the input edges seen in simplification are:");
+    for (i, e) in tables.edges().iter().enumerate() {
+        println!("{} {} {}", i, e.parent.0, e.child.0);
+    }
+
+    println!("the input nodes seen in simplification are:");
+    for (i, n) in tables.nodes().iter().enumerate() {
+        println!("{} {}", i, n.time.0);
     }
 
     // Process all edges since the last simplification.

--- a/forrustts-tables-trees/src/simplification.rs
+++ b/forrustts-tables-trees/src/simplification.rs
@@ -1067,6 +1067,11 @@ pub fn simplify_from_edge_buffer(
             println!("{} -> {} {} {}", p, j.node.0, j.left.0, j.right.0);
         }
     }
+    println!("node IDs alive at last simplification:");
+    for i in samples.edge_buffer_founder_nodes.iter()
+    {
+        println!("{}",i.0);
+    }
 
     // Process all edges since the last simplification.
     let mut max_time = Time::MIN;

--- a/forrustts-tables-trees/src/simplification.rs
+++ b/forrustts-tables-trees/src/simplification.rs
@@ -1061,6 +1061,13 @@ pub fn simplify_from_edge_buffer(
 ) -> Result<(), SimplificationError> {
     setup_simplification(samples, tables, flags, state, output)?;
 
+    println!("edge_buffer contents:");
+    for (i, p) in edge_buffer.0.head_iter().enumerate() {
+        for j in edge_buffer.0.values_iter(i as i32) {
+            println!("{} -> {} {} {}", p, j.node.0, j.left.0, j.right.0);
+        }
+    }
+
     // Process all edges since the last simplification.
     let mut max_time = Time::MIN;
     for n in samples.edge_buffer_founder_nodes.iter() {

--- a/forrustts-tables-trees/src/simplification.rs
+++ b/forrustts-tables-trees/src/simplification.rs
@@ -1061,30 +1061,6 @@ pub fn simplify_from_edge_buffer(
 ) -> Result<(), SimplificationError> {
     setup_simplification(samples, tables, flags, state, output)?;
 
-    println!("The samples list is:");
-    for s in samples.samples.iter() {
-        println!("{}", s.0);
-    }
-    println!("edge_buffer contents:");
-    for (i, p) in edge_buffer.0.head_iter().enumerate() {
-        for j in edge_buffer.0.values_iter(i as i32) {
-            println!("{} -> {} {} {}", p, j.node.0, j.left.0, j.right.0);
-        }
-    }
-    println!("node IDs alive at last simplification:");
-    for i in samples.edge_buffer_founder_nodes.iter() {
-        println!("{}", i.0);
-    }
-    println!("the input edges seen in simplification are:");
-    for (i, e) in tables.edges().iter().enumerate() {
-        println!("{} {} {}", i, e.parent.0, e.child.0);
-    }
-
-    println!("the input nodes seen in simplification are:");
-    for (i, n) in tables.nodes().iter().enumerate() {
-        println!("{} {}", i, n.time.0);
-    }
-
     // Process all edges since the last simplification.
     let mut max_time = Time::MIN;
     for n in samples.edge_buffer_founder_nodes.iter() {

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -631,6 +631,19 @@ pub fn neutral_wf(
                 &mut pop,
                 &mut output,
             );
+            println!("regular method: the nodes are:");
+            for (i, n) in pop.tables.nodes().iter().enumerate() {
+                println!("{} {}", i, TimeLLType::from(n.time));
+            }
+            println!("regular method: the simplified edges are:");
+            for (i, n) in pop.tables.edges().iter().enumerate() {
+                println!(
+                    "{} {} {}",
+                    i,
+                    TablesIdInteger::from(n.parent),
+                    TablesIdInteger::from(n.child)
+                );
+            }
             simplified = true;
         } else {
             simplified = false;
@@ -834,6 +847,14 @@ fn dispatch_simplification(
         Simplifying::No((tables, samples, state, output))
     } else {
         println!("dispatch, yo! {} {}", new_nodes.len(), new_edges.len());
+        println!("the new edges are");
+        for i in new_edges.iter() {
+            println!(
+                "{} {}",
+                TablesIdInteger::from(i.parent),
+                TablesIdInteger::from(i.child)
+            );
+        }
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = EdgeBuffer::default();
@@ -871,7 +892,13 @@ fn dispatch_simplification(
                         - first_child_node_after_last_simplification
                 }
             };
-            println!("{} -> {}, {} -> {}", TablesIdInteger::from(edge.parent), p, TablesIdInteger::from(edge.child), c);
+            println!(
+                "{} -> {}, {} -> {}",
+                TablesIdInteger::from(edge.parent),
+                p,
+                TablesIdInteger::from(edge.child),
+                c
+            );
             assert!(
                 (c as usize) < tables.nodes().len() + new_nodes.len(),
                 "{} {} {}",
@@ -996,6 +1023,26 @@ pub fn neutral_wf_simplify_separate_thread(
                 // happen w/new node IDs?
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
+                println!("simplified node table len = {}", tables.nodes().len());
+                println!("the nodes are:");
+                for (i, n) in tables.nodes().iter().enumerate() {
+                    println!("{} {}", i, TimeLLType::from(n.time));
+                }
+                println!("the simplified edges are:");
+                for (i, n) in tables.edges().iter().enumerate() {
+                    println!(
+                        "{} {} {}",
+                        i,
+                        TablesIdInteger::from(n.parent),
+                        TablesIdInteger::from(n.child)
+                    );
+                }
+                println!("next_node_id = {}", next_node_id);
+                println!(
+                    "first_child_node_after_last_simplification = {}",
+                    first_child_node_after_last_simplification
+                );
+
                 // remap parent nodes
                 for p in &mut pop.parents {
                     p.node0 = output.idmap[usize::from(p.node0)];

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -984,7 +984,7 @@ pub fn neutral_wf_simplify_separate_thread(
                 recrate,
                 birth_time.into(),
                 genome_length,
-                &mut pop.births,
+                &pop.births,
                 &mut rng,
                 &mut pop.parents,
                 &mut new_nodes,

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -918,7 +918,11 @@ pub fn neutral_wf_simplify_separate_thread(
     let recrate = match params.xovers.partial_cmp(&0.0) {
         Some(std::cmp::Ordering::Greater) => Some(params.xovers),
         Some(std::cmp::Ordering::Equal) => None,
-        Some(std::cmp::Ordering::Less) | None => panic!("invalid recombination rate"),
+        Some(std::cmp::Ordering::Less) | None => {
+            return Err(Box::new(SimulationError::ErrorMessage(
+                "recombination rate must be >= 0.0".to_string(),
+            )))
+        }
     };
 
     match params.simplification_interval {
@@ -1045,9 +1049,17 @@ pub fn neutral_wf_simplify_separate_thread(
     let mut return_tables = match Arc::try_unwrap(tables) {
         Ok(x) => match x.into_inner() {
             Ok(tables) => tables,
-            Err(_) => panic!("poisoned mutex"),
+            Err(_) => {
+                return Err(Box::new(SimulationError::ErrorMessage(
+                    "poisoned mutex".to_string(),
+                )))
+            }
         },
-        Err(_) => panic!("multiple references to tables still in play!"),
+        Err(_) => {
+            return Err(Box::new(SimulationError::ErrorMessage(
+                "multiple references to tables still in play!".to_string(),
+            )))
+        }
     };
 
     let mut is_alive: Vec<i32> = vec![0; return_tables.num_nodes()];
@@ -1065,7 +1077,11 @@ pub fn neutral_wf_simplify_separate_thread(
                 assert_eq!(x.len(), 1);
                 assert_eq!(x[0], 0);
             }
-            None => panic!("ancestral_state is None"),
+            None => {
+                return Err(Box::new(SimulationError::ErrorMessage(
+                    "ancestral_state is None".to_string(),
+                )))
+            }
         };
     }
     for m in return_tables.mutations() {
@@ -1074,7 +1090,11 @@ pub fn neutral_wf_simplify_separate_thread(
                 assert_eq!(x.len(), 1);
                 assert!(x[0] > 0);
             }
-            None => panic!("derived_state is None"),
+            None => {
+                return Err(Box::new(SimulationError::ErrorMessage(
+                    "derived_state is None".to_string(),
+                )))
+            }
         };
     }
 

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -902,6 +902,15 @@ fn dispatch_simplification(
             node_table.append(new_nodes);
             t.set_node_table(node_table);
         }
+
+        samples.edge_buffer_founder_nodes.clear();
+        for (i, p) in &mut pop.parents.iter_mut().enumerate() {
+            p.node0 = NodeId::from(2 * i); // utput.idmap[usize::from(p.node0)];
+            p.node1 = NodeId::from(2 * i + 1); // utput.idmap[usize::from(p.node0)];
+            samples.edge_buffer_founder_nodes.push(p.node0);
+            samples.edge_buffer_founder_nodes.push(p.node1);
+        }
+
         Simplifying::Yes(thread::spawn(move || {
             // consume data
             let inputs = SimplificationRoundTripData::new(samples, edge_buffer, state, output);
@@ -1075,6 +1084,7 @@ pub fn neutral_wf_simplify_separate_thread(
                 output = data.2;
             }
             Simplifying::Yes(handle) => {
+                println!("wrapping up simplification at {}", i64::from(birth_time));
                 let outputs = handle.join().unwrap();
                 simplified = true;
                 output = outputs.output;
@@ -1087,23 +1097,23 @@ pub fn neutral_wf_simplify_separate_thread(
                 first_child_node_after_last_simplification = next_node_id;
                 // remap parent nodes
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
-                {
-                    let t = tables.lock().unwrap();
-                    for p in &mut pop.parents {
-                        p.node0 = output.idmap[usize::from(p.node0)];
-                        p.node1 = output.idmap[usize::from(p.node1)];
-                        assert!(t.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
-                    }
-                }
+                // {
+                //     let t = tables.lock().unwrap();
+                //     for p in &mut pop.parents {
+                //         p.node0 = output.idmap[usize::from(p.node0)];
+                //         p.node1 = output.idmap[usize::from(p.node1)];
+                //         assert!(t.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
+                //     }
+                // }
 
-                // TODO: we can save a loop by merging the pushes into
-                // the previous loop
-                // Track what (remapped) nodes are now alive.
-                samples.edge_buffer_founder_nodes.clear();
-                for p in &pop.parents {
-                    samples.edge_buffer_founder_nodes.push(p.node0);
-                    samples.edge_buffer_founder_nodes.push(p.node1);
-                }
+                // // TODO: we can save a loop by merging the pushes into
+                // // the previous loop
+                // // Track what (remapped) nodes are now alive.
+                // samples.edge_buffer_founder_nodes.clear();
+                // for p in &pop.parents {
+                //     samples.edge_buffer_founder_nodes.push(p.node0);
+                //     samples.edge_buffer_founder_nodes.push(p.node1);
+                // }
             }
         }
     }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -853,7 +853,6 @@ fn dispatch_simplification(
                     //);
                     TablesIdInteger::from(edge.parent) + num_nodes
                         - first_child_node_after_last_simplification
-                        + 1
                 }
             };
             let c = match edge.child >= first_child_node_after_last_simplification {
@@ -869,7 +868,6 @@ fn dispatch_simplification(
                     //);
                     TablesIdInteger::from(edge.child) + num_nodes
                         - first_child_node_after_last_simplification
-                        + 1
                 }
             };
             assert!(
@@ -946,7 +944,7 @@ pub fn neutral_wf_simplify_separate_thread(
         next_node_id += 2;
     }
     assert_eq!(next_node_id, tables.nodes().len() as TablesIdInteger);
-    let mut first_child_node_after_last_simplification = 0;
+    let mut first_child_node_after_last_simplification = next_node_id;
 
     for i in 0..tables.num_nodes() {
         samples.edge_buffer_founder_nodes.push(i.into());
@@ -994,10 +992,6 @@ pub fn neutral_wf_simplify_separate_thread(
 
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
-                println!(
-                    "bananas {} {}",
-                    next_node_id, first_child_node_after_last_simplification
-                );
                 // remap parent nodes
                 for p in &mut pop.parents {
                     p.node0 = output.idmap[usize::from(p.node0)];

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -1104,6 +1104,28 @@ pub fn neutral_wf_simplify_separate_thread(
         }
     }
 
+    println!("we are done: {} {}", new_nodes.len(), new_edges.len());
+    match dispatch_simplification(
+        birth_time,
+        &mut pop,
+        &mut new_nodes,
+        &mut new_edges,
+        &mut next_node_id,
+        &mut first_child_node_after_last_simplification,
+        params.simplification_flags,
+        tables.clone(),
+        samples,
+        state,
+        output,
+    ) {
+        Simplifying::No(_) => println!("no"),
+        Simplifying::Yes(handle) => {
+            println!("yes");
+
+            let _outputs = handle.join().unwrap();
+        }
+    }
+
     // for birth_time in 1..(params.nsteps + 1) {
     //     deaths_and_parents(params.psurvival, &mut rng, &mut pop);
     //     generate_births_v2(

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -991,6 +991,8 @@ pub fn neutral_wf_simplify_separate_thread(
     loop {
         // Step 1: check if there's work to simplify
 
+        println!("check if we simplify at {}", birth_time);
+
         let simplifying = dispatch_simplification(
             birth_time,
             &mut pop,

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -894,10 +894,11 @@ pub fn neutral_wf_simplify_separate_thread(
     }
     assert_eq!(next_node_id, tables.nodes().len() as TablesIdInteger);
 
-    for i in 0..pop.tables.num_nodes() {
+    for i in 0..tables.num_nodes() {
         samples.edge_buffer_founder_nodes.push(i.into());
     }
 
+    let genome_length = tables.genome_length();
     let mut simplified = false;
     let mut edge_buffer = EdgeBuffer::default();
     let mut state = SimplificationBuffers::new();
@@ -976,7 +977,7 @@ pub fn neutral_wf_simplify_separate_thread(
             generate_births_v2(
                 breakpoint,
                 birth_time.into(),
-                pop.tables.genome_length(),
+                genome_length,
                 &mut pop.births,
                 &mut rng,
                 &mut pop.parents,
@@ -1077,9 +1078,9 @@ pub fn neutral_wf_simplify_separate_thread(
 
     if !simplified && actual_simplification_interval != -1 {
         if !new_nodes.is_empty() {
-            let mut node_table = pop.tables.dump_node_table();
+            let mut node_table = tables.dump_node_table();
             node_table.append(&mut new_nodes);
-            pop.tables.set_node_table(node_table);
+            tables.set_node_table(node_table);
         }
         simplify_and_remap_nodes(
             params.flags,
@@ -1091,16 +1092,16 @@ pub fn neutral_wf_simplify_separate_thread(
         );
     }
 
-    let mut is_alive: Vec<i32> = vec![0; pop.tables.num_nodes()];
+    let mut is_alive: Vec<i32> = vec![0; tables.num_nodes()];
 
     for p in pop.parents {
         is_alive[usize::from(p.node0)] = 1;
         is_alive[usize::from(p.node1)] = 1;
     }
 
-    mutate_tables(params.mutrate, &mut pop.tables, &mut rng);
+    mutate_tables(params.mutrate, &mut tables, &mut rng);
 
-    for s in pop.tables.sites() {
+    for s in tables.sites() {
         match &s.ancestral_state {
             Some(x) => {
                 assert_eq!(x.len(), 1);
@@ -1109,7 +1110,7 @@ pub fn neutral_wf_simplify_separate_thread(
             None => panic!("ancestral_state is None"),
         };
     }
-    for m in pop.tables.mutations() {
+    for m in tables.mutations() {
         match &m.derived_state {
             Some(x) => {
                 assert_eq!(x.len(), 1);
@@ -1119,5 +1120,5 @@ pub fn neutral_wf_simplify_separate_thread(
         };
     }
 
-    Ok((pop.tables, is_alive))
+    Ok((tables, is_alive))
 }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -856,6 +856,9 @@ pub fn neutral_wf_simplify_separate_thread(
     let mut birth_time: i64 = 1;
 
     loop {
+        // Step 1: check if there's work to simplify
+
+        // record new data while simplification is happening
         for _ in 1..(actual_simplification_interval + 1) {
             simplified = false;
             deaths_and_parents(params.psurvival, &mut rng, &mut pop);
@@ -872,14 +875,16 @@ pub fn neutral_wf_simplify_separate_thread(
             );
 
             birth_time += 1;
+
+            // We may exit if the simplification interval
+            // and/or the nsteps is a "funny" value
             if birth_time > params.nsteps {
                 break;
             }
         }
 
-        if birth_time > params.nsteps {
-            break;
-        }
+        // Join our simplification thread handle, if
+        // it exists
 
         fill_samples(&pop.parents, &mut samples);
         // transfer over our new nodes
@@ -913,6 +918,10 @@ pub fn neutral_wf_simplify_separate_thread(
             samples.edge_buffer_founder_nodes.push(p.node1);
         }
         simplified = true;
+
+        if birth_time > params.nsteps {
+            break;
+        }
     }
 
     // for birth_time in 1..(params.nsteps + 1) {

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -1078,6 +1078,7 @@ pub fn neutral_wf_simplify_separate_thread(
         }
         match simplifying {
             Simplifying::No(data) => {
+                println!("nope at time {}", i64::from(birth_time));
                 simplified = false;
                 samples = data.0;
                 state = data.1;
@@ -1095,6 +1096,13 @@ pub fn neutral_wf_simplify_separate_thread(
                 // happen w/new node IDs?
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
+                println!(
+                    "{} {} {} {}",
+                    next_node_id,
+                    first_child_node_after_last_simplification,
+                    new_nodes.len(),
+                    new_edges.len()
+                );
                 // remap parent nodes
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
                 // {

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -631,19 +631,6 @@ pub fn neutral_wf(
                 &mut pop,
                 &mut output,
             );
-            println!("regular method: the simplified nodes are:");
-            for (i, n) in pop.tables.nodes().iter().enumerate() {
-                println!("{} {}", i, TimeLLType::from(n.time));
-            }
-            println!("regular method: the simplified edges are:");
-            for (i, n) in pop.tables.edges().iter().enumerate() {
-                println!(
-                    "{} {} {}",
-                    i,
-                    TablesIdInteger::from(n.parent),
-                    TablesIdInteger::from(n.child)
-                );
-            }
             simplified = true;
         } else {
             simplified = false;
@@ -846,15 +833,6 @@ fn dispatch_simplification(
     if new_nodes.is_empty() {
         Simplifying::No((tables, samples, state, output))
     } else {
-        println!("dispatch, yo! {} {}", new_nodes.len(), new_edges.len());
-        println!("the new edges are");
-        for i in new_edges.iter() {
-            println!(
-                "{} {}",
-                TablesIdInteger::from(i.parent),
-                TablesIdInteger::from(i.child)
-            );
-        }
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = EdgeBuffer::default();
@@ -892,13 +870,6 @@ fn dispatch_simplification(
                         - first_child_node_after_last_simplification
                 }
             };
-            println!(
-                "{} -> {}, {} -> {}",
-                TablesIdInteger::from(edge.parent),
-                p,
-                TablesIdInteger::from(edge.child),
-                c
-            );
             assert!(
                 (c as usize) < tables.nodes().len() + new_nodes.len(),
                 "{} {} {}",
@@ -950,7 +921,6 @@ fn dispatch_simplification(
 pub fn neutral_wf_simplify_separate_thread(
     params: SimulationParams,
 ) -> Result<(TableCollection, Vec<i32>), Box<dyn std::error::Error>> {
-    println!("STARTING neutral_wf_simplify_separate_thread");
     // FIXME: gotta validate input params!
     // TODO: require a simplification interval > 0
     if !params.flags.contains(SimulationFlags::BUFFER_EDGES) {
@@ -1044,33 +1014,11 @@ pub fn neutral_wf_simplify_separate_thread(
                 // happen w/new node IDs?
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
-                println!("simplified node table len = {}", tables.nodes().len());
-                println!("the simplified nodes are:");
-                for (i, n) in tables.nodes().iter().enumerate() {
-                    println!("{} {}", i, TimeLLType::from(n.time));
-                }
-                println!("the simplified edges are:");
-                for (i, n) in tables.edges().iter().enumerate() {
-                    println!(
-                        "{} {} {}",
-                        i,
-                        TablesIdInteger::from(n.parent),
-                        TablesIdInteger::from(n.child)
-                    );
-                }
-                println!("next_node_id = {}", next_node_id);
-                println!(
-                    "first_child_node_after_last_simplification = {}",
-                    first_child_node_after_last_simplification
-                );
-
                 // remap parent nodes
-                let mut zz = 0;
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
                 for p in &mut pop.parents {
                     p.node0 = output.idmap[usize::from(p.node0)];
                     p.node1 = output.idmap[usize::from(p.node1)];
-                    zz += 2;
                     assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
                 }
 

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -990,6 +990,8 @@ pub fn neutral_wf_simplify_separate_thread(
                 state = outputs.state;
                 samples = outputs.samples;
 
+                // FIXME: this is probalby our issue, causing "bad" things to
+                // happen w/new node IDs?
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
                 // remap parent nodes

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -1052,9 +1052,12 @@ pub fn neutral_wf_simplify_separate_thread(
                 );
 
                 // remap parent nodes
+                let mut zz = 0;
+                // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
                 for p in &mut pop.parents {
-                    p.node0 = output.idmap[usize::from(p.node0)];
-                    p.node1 = output.idmap[usize::from(p.node1)];
+                    p.node0 = NodeId::from(zz); //output.idmap[usize::from(p.node0)];
+                    p.node1 = NodeId::from(zz + 1); //output.idmap[usize::from(p.node1)];
+                    zz += 2;
                     // FIXME: restore
                     // assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
                 }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -884,8 +884,8 @@ fn dispatch_simplification(
         // NOTE: this loop can be done above, once things are working
         samples.edge_buffer_founder_nodes.clear();
         for (i, p) in &mut pop.parents.iter_mut().enumerate() {
-            p.node0 = NodeId::from(2 * i); // utput.idmap[usize::from(p.node0)];
-            p.node1 = NodeId::from(2 * i + 1); // utput.idmap[usize::from(p.node0)];
+            p.node0 = NodeId::from(2 * i);
+            p.node1 = NodeId::from(2 * i + 1);
             samples.edge_buffer_founder_nodes.push(p.node0);
             samples.edge_buffer_founder_nodes.push(p.node1);
         }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -781,6 +781,9 @@ fn generate_births_v2(
                     .unwrap();
             }
         }
+        pop.parents[b.index].index = b.index;
+        pop.parents[b.index].node0 = new_node_0;
+        pop.parents[b.index].node1 = new_node_1;
     }
 }
 

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -716,9 +716,10 @@ fn simplify_from_edge_buffer_channel(
 
     let mut t = tables.lock().unwrap();
 
-    simplify_from_edge_buffer(
+    simplify_from_edge_buffer_with_node_mapping(
         &inputs.samples,
         flags,
+        |a: NodeId| a,
         &mut state,
         &mut edge_buffer,
         &mut t,

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -834,9 +834,10 @@ fn dispatch_simplification(
         let mut samples = samples;
         fill_samples(&pop.parents, &mut samples);
         // transfer over our new nodes
-        let mut node_table = pop.tables.dump_node_table();
+        let mut tables = tables; // Take over ownership
+        let mut node_table = tables.dump_node_table();
         node_table.append(new_nodes);
-        pop.tables.set_node_table(node_table);
+        tables.set_node_table(node_table);
         // consume data
         let inputs = SimplificationRoundTripData::new(samples, edge_buffer, tables, state, output);
 

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -833,6 +833,7 @@ fn dispatch_simplification(
     if new_nodes.is_empty() {
         Simplifying::No((tables, samples, state, output))
     } else {
+        println!("dispatch, yo! {} {}", new_nodes.len(), new_edges.len());
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = EdgeBuffer::default();
@@ -870,6 +871,7 @@ fn dispatch_simplification(
                         - first_child_node_after_last_simplification
                 }
             };
+            println!("{} -> {}, {} -> {}", TablesIdInteger::from(edge.parent), p, TablesIdInteger::from(edge.child), c);
             assert!(
                 (c as usize) < tables.nodes().len() + new_nodes.len(),
                 "{} {} {}",

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -798,6 +798,7 @@ pub fn neutral_wf_simplify_separate_thread(
         );
         if actual_simplification_interval != -1 && birth_time % actual_simplification_interval == 0
         {
+            fill_samples(&pop.parents, &mut samples);
             // consume data
             let inputs = SimplificationRoundTripData::new(
                 samples,
@@ -828,7 +829,6 @@ pub fn neutral_wf_simplify_separate_thread(
                 samples.edge_buffer_founder_nodes.push(p.node0);
                 samples.edge_buffer_founder_nodes.push(p.node1);
             }
-
             simplified = true;
         } else {
             simplified = false;

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -739,6 +739,7 @@ fn generate_births_v2(
     parents: &mut [Parent],
     new_nodes: &mut NodeTable,
     new_edges: &mut EdgeTable,
+    edge_buffer: &mut EdgeBuffer,
     next_node_id: &mut TablesIdInteger,
 ) {
     for b in births {
@@ -770,6 +771,9 @@ fn generate_births_v2(
                         match action {
                             SegmentAction::Swap => (),
                             SegmentAction::Process(segment) => {
+                                edge_buffer
+                                    .record_edge(pnodes.0, c, segment.left, segment.right)
+                                    .unwrap();
                                 new_edges.push(Edge {
                                     parent: pnodes.0,
                                     child: c,
@@ -782,6 +786,9 @@ fn generate_births_v2(
                     }
                 }
                 None => {
+                    edge_buffer
+                        .record_edge(pnodes.0, c, 0, genome_length)
+                        .unwrap();
                     new_edges.push(Edge {
                         parent: pnodes.0,
                         child: c,
@@ -962,6 +969,8 @@ pub fn neutral_wf_simplify_separate_thread(
             output,
         );
 
+        let mut edge_buffer = EdgeBuffer::default();
+
         for _ in 1..(actual_simplification_interval + 1) {
             deaths_and_parents(params.psurvival, &mut rng, &mut pop);
             generate_births_v2(
@@ -973,6 +982,7 @@ pub fn neutral_wf_simplify_separate_thread(
                 &mut pop.parents,
                 &mut new_nodes,
                 &mut new_edges,
+                &mut edge_buffer,
                 &mut next_node_id,
             );
 

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -826,7 +826,7 @@ fn dispatch_simplification(
     if new_nodes.is_empty() {
         Simplifying::No((samples, state, output))
     } else {
-        println!("Firing off some simplification at {}", birth_time);
+        //println!("Firing off some simplification at {}", birth_time);
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = EdgeBuffer::default();
@@ -991,7 +991,7 @@ pub fn neutral_wf_simplify_separate_thread(
     loop {
         // Step 1: check if there's work to simplify
 
-        println!("check if we simplify at {}", birth_time);
+        //println!("check if we simplify at {}", birth_time);
 
         let simplifying = dispatch_simplification(
             birth_time,
@@ -1057,7 +1057,7 @@ pub fn neutral_wf_simplify_separate_thread(
         // record new data while simplification is happening
         match simplifying {
             Simplifying::No(data) => {
-                println!("nope at time {}", i64::from(birth_time));
+                //println!("nope at time {}", i64::from(birth_time));
                 simplified = false;
                 samples = data.0;
                 state = data.1;
@@ -1081,12 +1081,13 @@ pub fn neutral_wf_simplify_separate_thread(
                     // We may exit if the simplification interval
                     // and/or the nsteps is a "funny" value
                     if birth_time > params.nsteps {
+                        //println!("breaking in ::No");
                         break;
                     }
                 }
             }
             Simplifying::Yes(handle) => {
-                println!("wrapping up simplification at {}", i64::from(birth_time));
+                //println!("wrapping up simplification at {}", i64::from(birth_time));
                 let outputs = handle.join().unwrap();
                 simplified = true;
                 output = outputs.output;
@@ -1097,13 +1098,13 @@ pub fn neutral_wf_simplify_separate_thread(
                 // happen w/new node IDs?
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
-                println!(
-                    "{} {} {} {}",
-                    next_node_id,
-                    first_child_node_after_last_simplification,
-                    new_nodes.len(),
-                    new_edges.len()
-                );
+                // println!(
+                //     "{} {} {} {}",
+                //     next_node_id,
+                //     first_child_node_after_last_simplification,
+                //     new_nodes.len(),
+                //     new_edges.len()
+                // );
                 // remap parent nodes
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
                 // {
@@ -1123,12 +1124,13 @@ pub fn neutral_wf_simplify_separate_thread(
                 //     samples.edge_buffer_founder_nodes.push(p.node0);
                 //     samples.edge_buffer_founder_nodes.push(p.node1);
                 // }
+                if birth_time > params.nsteps {
+                    //println!("breaking on ::Yes");
+                    break;
+                }
+                //if !new_nodes.is_empty() {
             }
         }
-        if birth_time > params.nsteps {
-            break;
-        }
-        //if !new_nodes.is_empty() {
     }
 
     // for birth_time in 1..(params.nsteps + 1) {

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -913,6 +913,19 @@ fn dispatch_simplification(
         assert!(new_edges.is_empty());
         let mut samples = samples;
         fill_samples(&pop.parents, &mut samples);
+        assert_eq!(pop.parents.len() * 2, samples.samples.len());
+        for p in pop.parents.iter_mut() {
+            if p.node0 >= first_child_node_after_last_simplification {
+                p.node0 = (TablesIdInteger::from(p.node0) + num_nodes
+                    - first_child_node_after_last_simplification)
+                    .into();
+            }
+            if p.node1 >= first_child_node_after_last_simplification {
+                p.node1 = (TablesIdInteger::from(p.node1) + num_nodes
+                    - first_child_node_after_last_simplification)
+                    .into();
+            }
+        }
         for s in samples.samples.iter_mut() {
             if *s >= first_child_node_after_last_simplification {
                 *s = (TablesIdInteger::from(*s) + num_nodes
@@ -1055,11 +1068,10 @@ pub fn neutral_wf_simplify_separate_thread(
                 let mut zz = 0;
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
                 for p in &mut pop.parents {
-                    p.node0 = NodeId::from(zz); //output.idmap[usize::from(p.node0)];
-                    p.node1 = NodeId::from(zz + 1); //output.idmap[usize::from(p.node1)];
+                    p.node0 = output.idmap[usize::from(p.node0)];
+                    p.node1 = output.idmap[usize::from(p.node1)];
                     zz += 2;
-                    // FIXME: restore
-                    // assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
+                    assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
                 }
 
                 // TODO: we can save a loop by merging the pushes into

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -823,20 +823,14 @@ fn dispatch_simplification(
     // If new nodes is empty, there's no work to be done
     // and we can return consumed stuff
     if new_nodes.is_empty() {
-        println!("no");
         Simplifying::No((tables, samples, edge_buffer, state, output))
     } else {
-        println!("yes");
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = edge_buffer; // take ownership
         std::mem::swap(&mut edge_buffer, &mut pop.edge_buffer); // Take the buffer from the population
         let mut samples = samples;
         fill_samples(&pop.parents, &mut samples);
-        println!("{}", samples.samples.len());
-        for i in &samples.samples[0..10] {
-            println!("{}", i32::from(*i));
-        }
         // transfer over our new nodes
         let mut tables = tables; // Take over ownership
         let mut node_table = tables.dump_node_table();
@@ -847,7 +841,6 @@ fn dispatch_simplification(
 
         // send data to simplification
         let outputs = simplify_from_edge_buffer_channel(flags, inputs).unwrap();
-        println!("returning...");
         Simplifying::Yes(outputs)
     }
 }
@@ -914,7 +907,6 @@ pub fn neutral_wf_simplify_separate_thread(
     let mut birth_time: i64 = 1;
 
     loop {
-        println!("{}", birth_time);
         // Step 1: check if there's work to simplify
 
         let simplifying = dispatch_simplification(

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -827,7 +827,7 @@ fn dispatch_simplification(
     if new_nodes.is_empty() {
         Simplifying::No((samples, state, output))
     } else {
-        println!("Firing off some simplification at {}", birth_time);
+        //println!("Firing off some simplification at {}", birth_time);
         // Else, we have to do some moves of the big
         // data structures and return a JoinHandle
         let mut edge_buffer = EdgeBuffer::default();
@@ -1011,10 +1011,10 @@ pub fn neutral_wf_simplify_separate_thread(
             output,
         );
 
-        println!(
-            "after check: {} {}",
-            next_node_id, first_child_node_after_last_simplification
-        );
+        // println!(
+        //     "after check: {} {}",
+        //     next_node_id, first_child_node_after_last_simplification
+        // );
 
         for _ in 1..(actual_simplification_interval + 1) {
             deaths_and_parents(params.psurvival, &mut rng, &mut pop);
@@ -1035,7 +1035,7 @@ pub fn neutral_wf_simplify_separate_thread(
             // We may exit if the simplification interval
             // and/or the nsteps is a "funny" value
             if birth_time > params.nsteps {
-                println!("breaking in ::No");
+                //println!("breaking in ::No");
                 break;
             }
         }
@@ -1043,17 +1043,17 @@ pub fn neutral_wf_simplify_separate_thread(
         // record new data while simplification is happening
         match simplifying {
             Simplifying::No(data) => {
-                println!("nope at time {}", birth_time);
+                //println!("nope at time {}", birth_time);
                 simplified = false;
                 samples = data.0;
                 state = data.1;
                 output = data.2;
             }
             Simplifying::Yes(handle) => {
-                println!(
-                    "wrapping up simplification at {} {} {}",
-                    birth_time, next_node_id, first_child_node_after_last_simplification
-                );
+                //println!(
+                //    "wrapping up simplification at {} {} {}",
+                //    birth_time, next_node_id, first_child_node_after_last_simplification
+                //);
                 let outputs = handle.join().unwrap();
                 simplified = true;
                 output = outputs.output;
@@ -1066,15 +1066,15 @@ pub fn neutral_wf_simplify_separate_thread(
                 first_child_node_after_last_simplification = next_node_id;
                 {
                     let t = tables.lock().unwrap();
-                    println!(
-                        "{} {} {} {}|{} {}",
-                        next_node_id,
-                        first_child_node_after_last_simplification,
-                        new_nodes.len(),
-                        new_edges.len(),
-                        t.nodes().len(),
-                        t.edges().len(),
-                    );
+                    //println!(
+                    //    "{} {} {} {}|{} {}",
+                    //    next_node_id,
+                    //    first_child_node_after_last_simplification,
+                    //    new_nodes.len(),
+                    //    new_edges.len(),
+                    //    t.nodes().len(),
+                    //    t.edges().len(),
+                    //);
                 }
                 // remap parent nodes
                 // FIXME NOTE TODO: fascinating--the idmap is coming back funky?
@@ -1104,7 +1104,6 @@ pub fn neutral_wf_simplify_separate_thread(
         }
     }
 
-    println!("we are done: {} {}", new_nodes.len(), new_edges.len());
     match dispatch_simplification(
         birth_time,
         &mut pop,
@@ -1118,10 +1117,8 @@ pub fn neutral_wf_simplify_separate_thread(
         state,
         output,
     ) {
-        Simplifying::No(_) => println!("no"),
+        Simplifying::No(_) => (),
         Simplifying::Yes(handle) => {
-            println!("yes");
-
             let _outputs = handle.join().unwrap();
         }
     }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -930,6 +930,7 @@ fn dispatch_simplification(
 pub fn neutral_wf_simplify_separate_thread(
     params: SimulationParams,
 ) -> Result<(TableCollection, Vec<i32>), Box<dyn std::error::Error>> {
+    println!("STARTING neutral_wf_simplify_separate_thread");
     // FIXME: gotta validate input params!
     // TODO: require a simplification interval > 0
     if !params.flags.contains(SimulationFlags::BUFFER_EDGES) {

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -913,6 +913,13 @@ fn dispatch_simplification(
         assert!(new_edges.is_empty());
         let mut samples = samples;
         fill_samples(&pop.parents, &mut samples);
+        for s in samples.samples.iter_mut() {
+            if *s >= first_child_node_after_last_simplification {
+                *s = (TablesIdInteger::from(*s) + num_nodes
+                    - first_child_node_after_last_simplification)
+                    .into();
+            }
+        }
         // transfer over our new nodes
         let mut tables = tables; // Take over ownership
         let mut node_table = tables.dump_node_table();
@@ -1048,7 +1055,8 @@ pub fn neutral_wf_simplify_separate_thread(
                 for p in &mut pop.parents {
                     p.node0 = output.idmap[usize::from(p.node0)];
                     p.node1 = output.idmap[usize::from(p.node1)];
-                    assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
+                    // FIXME: restore
+                    // assert!(tables.node(p.node0).flags & NodeFlags::IS_SAMPLE.bits() > 0);
                 }
 
                 // TODO: we can save a loop by merging the pushes into

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -631,7 +631,7 @@ pub fn neutral_wf(
                 &mut pop,
                 &mut output,
             );
-            println!("regular method: the nodes are:");
+            println!("regular method: the simplified nodes are:");
             for (i, n) in pop.tables.nodes().iter().enumerate() {
                 println!("{} {}", i, TimeLLType::from(n.time));
             }
@@ -1025,7 +1025,7 @@ pub fn neutral_wf_simplify_separate_thread(
                 next_node_id = samples.samples.len() as TablesIdInteger;
                 first_child_node_after_last_simplification = next_node_id;
                 println!("simplified node table len = {}", tables.nodes().len());
-                println!("the nodes are:");
+                println!("the simplified nodes are:");
                 for (i, n) in tables.nodes().iter().enumerate() {
                     println!("{} {}", i, TimeLLType::from(n.time));
                 }

--- a/forrustts/tests/neutral_wright_fisher.rs
+++ b/forrustts/tests/neutral_wright_fisher.rs
@@ -883,8 +883,8 @@ fn dispatch_simplification(
         }
         assert!(new_edges.is_empty());
         let mut samples = samples;
-        fill_samples(&pop.parents, &mut samples);
-        assert_eq!(pop.parents.len() * 2, samples.samples.len());
+        //fill_samples(&pop.parents, &mut samples);
+        samples.samples.clear();
         for p in pop.parents.iter_mut() {
             if p.node0 >= first_child_node_after_last_simplification {
                 p.node0 = (TablesIdInteger::from(p.node0) + num_nodes
@@ -896,14 +896,10 @@ fn dispatch_simplification(
                     - first_child_node_after_last_simplification)
                     .into();
             }
+            samples.samples.push(p.node0);
+            samples.samples.push(p.node1);
         }
-        for s in samples.samples.iter_mut() {
-            if *s >= first_child_node_after_last_simplification {
-                *s = (TablesIdInteger::from(*s) + num_nodes
-                    - first_child_node_after_last_simplification)
-                    .into();
-            }
-        }
+        assert_eq!(pop.parents.len() * 2, samples.samples.len());
         // transfer over our new nodes
         let mut tables = tables; // Take over ownership
         let mut node_table = tables.dump_node_table();

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -3,8 +3,8 @@
 cargo build --all-targets
 cargo build --all-targets --release
 
-./target/release/examples/forward_simulation --popsize 5000 --nsteps 5000 -x 1e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. > /dev/null
-./target/release/examples/forward_simulation --popsize 5000 --nsteps 5000 -x 1e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads > /dev/null
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 50000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 50000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -3,8 +3,10 @@
 cargo build --all-targets
 cargo build --all-targets --release
 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -3,10 +3,10 @@
 cargo build --all-targets
 cargo build --all-targets --release
 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
-# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o regular.trees --mutrate 0.
+# ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o consume.trees --mutrate 0. --threads
+./target/release/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
+./target/release/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
+python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 cargo build --all-targets
+cargo build --all-targets --release
 
-# ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o regular.trees --mutrate 0.
-# ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o consume.trees --mutrate 0. --threads
-./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
-./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
+./target/release/examples/forward_simulation --popsize 5000 --nsteps 5000 -x 1e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. > /dev/null
+./target/release/examples/forward_simulation --popsize 5000 --nsteps 5000 -x 1e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads > /dev/null
+# ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
+# ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+cargo build --all-targets
+
 # ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o regular.trees --mutrate 0.
 # ./target/release/examples/forward_simulation --popsize 5000 --nsteps 10000 -x 1e-3 -S 101 -s 100 -o consume.trees --mutrate 0. --threads
-./target/release/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
-./target/release/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
+./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
+./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -3,10 +3,10 @@
 cargo build --all-targets
 cargo build --all-targets --release
 
-# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 1000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+# /usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py

--- a/quickcheck.sh
+++ b/quickcheck.sh
@@ -3,8 +3,8 @@
 cargo build --all-targets
 cargo build --all-targets --release
 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 50000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
-/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 50000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o regular.trees --mutrate 0. 
+/usr/bin/time -f "%e %M" ./target/release/examples/forward_simulation --popsize 5000 --nsteps 100000 -x 5e-3 -S 10101 -s 100 -o consume.trees --mutrate 0. --threads 
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o regular.trees --mutrate 0.
 # ./target/debug/examples/forward_simulation --popsize 2 --nsteps 2 -x 0. -S 101 -s 1 -o consume.trees --mutrate 0. --threads
 python compare.py


### PR DESCRIPTION
- start on consume/simplify/return scheme
- close??
- update forward_simulation example to call new evolve fn
- Fix error in final assertions in forward_simulation.rs
- fill samples prior to simplifying
- start on new logic, but not working yet.
- fix new recorder
- use a temp node table
- move to loop{} for control flow
- reorg. comment on our aspirational goals
