### PR TITLE
refactor(tables-trees): Streamline error types

### DIFF
--- a/forrustts-tables-trees/src/simplification.rs
+++ b/forrustts-tables-trees/src/simplification.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 /// Error type returned by tree sequence
 /// simplification
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum SimplificationError {
     /// Usef for error reporting by the simplification algorithm.
     #[error("{0:?}")]
@@ -1252,10 +1252,10 @@ mod test_simpify_tables {
         )
         .map_or_else(
             |x: SimplificationError| {
-                assert_eq!(
+                assert!(matches!(
                     x,
                     SimplificationError::TableValidationError(TablesError::EdgesNotSortedByLeft),
-                )
+                ))
             },
             |_| panic!(),
         );

--- a/forrustts-tables-trees/src/tables.rs
+++ b/forrustts-tables-trees/src/tables.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use thiserror::Error;
 
 /// Error type related to [``TableCollection``]
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum TablesError {
     /// Returned by [``TableCollection::new``].
     #[error("Invalid genome length")]
@@ -1399,7 +1399,7 @@ mod test_tables {
     #[test]
     fn test_bad_genome_length() {
         TableCollection::new(Position::from(0)).map_or_else(
-            |x: TablesError| assert_eq!(x, TablesError::InvalidGenomeLength),
+            |x: TablesError| assert!(matches!(x, TablesError::InvalidGenomeLength)),
             |_| panic!(),
         );
     }
@@ -1426,26 +1426,12 @@ mod test_tables {
         let mut tables = TableCollection::new(10).unwrap();
 
         tables.add_edge(-1, 1, 1, 2).map_or_else(
-            |x: TablesError| {
-                assert_eq!(
-                    x,
-                    TablesError::InvalidPosition {
-                        found: Position::from(-1)
-                    }
-                )
-            },
+            |x: TablesError| assert!(matches!(x, TablesError::InvalidPosition { found: _ })),
             |_| panic!(),
         );
 
         tables.add_edge(1, -1, 1, 2).map_or_else(
-            |x: TablesError| {
-                assert_eq!(
-                    x,
-                    TablesError::InvalidLeftRight {
-                        found: (Position::from(1), Position::from(-1))
-                    }
-                )
-            },
+            |x: TablesError| assert!(matches!(x, TablesError::InvalidLeftRight { found: (_, _) })),
             |_| panic!(),
         );
     }
@@ -1456,24 +1442,24 @@ mod test_tables {
 
         tables.add_edge(0, 1, -1, 2).map_or_else(
             |x: TablesError| {
-                assert_eq!(
+                assert!(matches!(
                     x,
                     TablesError::InvalidNodeValue {
                         found: NodeId::NULL
                     }
-                )
+                ))
             },
             |_| panic!(),
         );
 
         tables.add_edge(0, 1, 1, -2).map_or_else(
             |x: TablesError| {
-                assert_eq!(
+                assert!(matches!(
                     x,
                     TablesError::InvalidNodeValue {
                         found: NodeId::NULL
                     }
-                )
+                ))
             },
             |_| panic!(),
         );

--- a/tests/stochastic_simplification_tests.rs
+++ b/tests/stochastic_simplification_tests.rs
@@ -149,7 +149,10 @@ fn compare_buffer_vs_sort_overlapping_gens() {
     tables_buffer
         .build_indexes(IndexTablesFlags::empty())
         .unwrap();
-    assert_eq!(tables.count_trees(), tables_buffer.count_trees());
+    assert_eq!(
+        tables.count_trees().unwrap(),
+        tables_buffer.count_trees().unwrap()
+    );
 
     let ts = TreeSequence::new(tables, TreeSequenceFlags::empty()).unwrap();
     let ts_buffer = TreeSequence::new(tables_buffer, TreeSequenceFlags::empty()).unwrap();


### PR DESCRIPTION
* Remove need for PartialEq, Eq
  * prefer matching to equality comparison in tests.
* TreesError now has a TablesErrorVariant
* forrustts_core::Error now a variant of TreesError.
* Remove use of Box'd errors when creating TreeSequences
