### PR TITLE
Abstract the genetic map traits with respect to random number generation type.

### DIFF
--- a/forrustts-genetic-maps/src/lib.rs
+++ b/forrustts-genetic-maps/src/lib.rs
@@ -67,7 +67,7 @@ impl PositionVec {
 #[derive(Debug)]
 pub struct BoxedGeneticMap<T>
 where
-    T: Rng + Send + Sync,
+    T: Send + Sync,
 {
     map: Vec<Box<dyn GeneticMapElement<T>>>,
     breakpoints: PositionVec,
@@ -75,7 +75,7 @@ where
 
 impl<T> BoxedGeneticMap<T>
 where
-    T: Rng + Send + Sync,
+    T: Send + Sync,
 {
     pub fn new() -> Self {
         Self::default()
@@ -95,7 +95,7 @@ where
 
 impl<T> Default for BoxedGeneticMap<T>
 where
-    T: Rng + Send + Sync,
+    T: Send + Sync,
 {
     fn default() -> Self {
         Self {
@@ -107,7 +107,7 @@ where
 
 impl<T> GeneticMap<T> for BoxedGeneticMap<T>
 where
-    T: Rng + Send + Sync,
+    T: Send + Sync,
 {
     fn generate_breakpoints(&mut self, rng: &mut T) {
         self.breakpoints.0.clear();

--- a/forrustts-genetic-maps/src/traits.rs
+++ b/forrustts-genetic-maps/src/traits.rs
@@ -1,11 +1,7 @@
 use core::fmt::Debug;
 use forrustts_core::newtypes::Position;
-use rand::Rng;
 
-pub trait GeneticMapElementCore<T>
-where
-    T: Rng,
-{
+pub trait GeneticMapElementCore<T> {
     fn begin(&self) -> Position;
     fn end(&self) -> Position;
     fn generate_breakpoints(&self, rng: &mut T, breakpoints: &mut crate::PositionVec);
@@ -24,21 +20,18 @@ where
 
 pub trait GeneticMapElement<T>: GeneticMapElementCore<T> + Send + Sync + Debug
 where
-    T: Rng + Send + Sync,
+    T: Send + Sync + Debug,
 {
 }
 
 impl<G, T> GeneticMapElement<T> for G
 where
     G: GeneticMapElementCore<T> + Send + Sync + Debug,
-    T: Rng + Send + Sync + Debug,
+    T: Send + Sync + Debug,
 {
 }
 
-pub trait GeneticMap<T>
-where
-    T: Rng,
-{
+pub trait GeneticMap<T> {
     fn generate_breakpoints(&mut self, rng: &mut T);
     fn breakpoints(&self) -> &[Position];
 }


### PR DESCRIPTION
Work in progress.

We want the genetic map traits to not rely exclusively on rand's Rng trait.

Currently, the PR uses a simple marker trait to get the job done.
The marker trait method is a bit weird: almost any client-defined type can be compatible.
Gotta think more on this one.
